### PR TITLE
Install update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
         - libgtest-dev
         - python3
         - python3-pip
-        # - cmake
+        - cmake # needed for building gtests
     
   sources:
         - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
         - libgtest-dev
         - python3
         - python3-pip
-        - cmake
+        # - cmake
     
   sources:
         - ubuntu-toolchain-r-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (CORE_USE_CUDA)
 endif()
 #############################################
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-attributes")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-attributes -Wno-deprecated")
 
 # gather list of source files
 if (CORE_USE_CUDA)   

--- a/ci/.travis_docs.sh
+++ b/ci/.travis_docs.sh
@@ -9,6 +9,10 @@ then
 
     cd ..
 
+    echo "sourcing conda"
+    . /home/travis/miniconda/etc/profile.d/conda.sh
+    conda activate feat-env
+
     echo "Building mkdocs"
     mkdocs build --verbose --clean
 fi

--- a/ci/.travis_docs.sh
+++ b/ci/.travis_docs.sh
@@ -5,7 +5,7 @@ then
     cd docs
     doxygen Doxyfile
 
-    echo "docs build successfully"
+    echo "doxygen docs build successfully"
 
     cd ..
 
@@ -13,6 +13,8 @@ then
     . /home/travis/miniconda/etc/profile.d/conda.sh
     conda activate feat-env
 
-    echo "Building mkdocs"
+    echo "mkdocs location:"
+    which mkdocs
+    echo "Building website"
     mkdocs build --verbose --clean
 fi

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -39,35 +39,44 @@ echo "installing shogun and eigen via conda..."
 wget http://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
-
+echo "creating conda environment"
+conda config --set always_yes yes
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas
+# conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
+conda activate test-environment
 
 # conda update --yes conda
-conda install --yes -c conda-forge shogun-cpp eigen
+# conda install --yes -c conda-forge shogun-cpp eigen
 
 # export EIGEN3_INCLUDE_DIR="$(pwd)/eigen-3.3.4/"
-# echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
 # conda install -c conda-forge eigen
 
 # the new version of json-c seems to be missing a fn shogun is linked to;
 # force install of older version
-conda install --yes json-c=0.12.1-0
+# conda install --yes json-c=0.12.1-0
 
-export SHOGUN_LIB=/home/travis/miniconda/lib/
-export SHOGUN_DIR=/home/travis/miniconda/include/
 # commending out the following installs which should be triggered
 # by call to setup.py
-echo "installing cython using conda..."
-conda install --yes cython
+# echo "installing cython using conda..."
+# conda install --yes cython
 
-echo "installing scikit-learn via conda..."
-conda install --yes scikit-learn
+# echo "installing scikit-learn via conda..."
+# conda install --yes scikit-learn
 
-echo "installing pandas via conda..."
-conda install --yes pandas
+# echo "installing pandas via conda..."
+# conda install --yes pandas
 
 echo "printing conda environment"
 conda-env export
 ##########CONDA##############
+
+# set environment variables for eigen and shogun includes
+export EIGEN3_INCLUDE_DIR="$HOME/miniconda/envs/test-environment/include/eigen3/"
+echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
+
+export SHOGUN_LIB=/home/travis/miniconda/envs/test-environment/lib/
+export SHOGUN_DIR=/home/travis/miniconda/envs/test-environment/include/
+
 
 #building and installing google tests
 echo "installing google test"

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -19,7 +19,7 @@ conda activate feat-env
 if [ "$TRAVIS_BRANCH" = "master" ]
 then
     echo "installing mkdocs"
-    conda install mkdocs==1.1 mkdocs-material pymdown-extensions pygments
+    conda install -c conda-forge mkdocs==1.1 mkdocs-material pymdown-extensions pygments
     echo "mkdocs version"
     mkdocs --version
 fi

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -50,6 +50,7 @@ then
     mkdocs --version
 fi
 
+which conda
 conda info -a
 
 # conda update --yes conda

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -41,6 +41,7 @@ bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 source "$HOME/miniconda/etc/profile.d/conda.sh"
 hash -r
+conda info -a
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
 conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas
@@ -103,7 +104,7 @@ cd $old_path; pwd
 echo "installing feat..."
 mkdir build;
 cd build; pwd
-cmake -DTEST=ON -DEIGEN_DIR=OFF -DSHOGUN_DIR=ON ..
+cmake -DTEST=ON -DEIGEN_DIR=ON -DSHOGUN_DIR=ON ..
 cd ..
 make -C build VERBOSE=1
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -36,7 +36,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.4 json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.4 json-c=0.12.1-0 cython=0.29.12 scikit-learn pandas wheel setuptools
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
 conda activate test-environment

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -1,20 +1,15 @@
-# echo "cmake version:"
-# cmake --version
-# echo "sudo cmake version:"
-# sudo cmake --version
-
-##########CONDA##############
+##############################
+# conda setup and installation
+##############################
 
 echo "installing shogun and eigen via conda..."
-wget http://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O miniconda.sh
+wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 . "$HOME/miniconda/etc/profile.d/conda.sh"
 hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-# cython=0.29.12
-# conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools=41.0.1
 conda env create -f ci/test-environment.yml
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
@@ -41,19 +36,18 @@ python --version
 
 echo "cython path is..."
 which cython
-##########CONDA##############
 
 # set environment variables for eigen and shogun includes
 export EIGEN3_INCLUDE_DIR="$HOME/miniconda/envs/feat-env/include/eigen3/"
 echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
-
 export SHOGUN_LIB=/home/travis/miniconda/envs/feat-env/lib/
 echo "SHOGUN_LIB set to $SHOGUN_LIB"
 export SHOGUN_DIR=/home/travis/miniconda/envs/feat-env/include/
 echo "SHOGUN_DIR set to $SHOGUN_DIR"
 
-
+####################################
 #building and installing google tests
+####################################
 echo "installing google test"
 old_path=$(pwd)
 
@@ -72,16 +66,7 @@ cd $old_path; pwd
 ###################
 # feat installation
 ###################
-echo "installing feat..."
-mkdir build;
-cd build; pwd
-echo "which cmake?"
-which cmake
-cmake -DTEST=ON -DEIGEN_DIR=ON -DSHOGUN_DIR=ON ..
-cd ..
-make -C build VERBOSE=1
-
-echo "installing wrapper"
-cd ./python
-python setup.py install
-cd ..
+echo "configuring feat..."
+./configure tests
+echo "install feat..."
+./install tests y

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -19,7 +19,7 @@ conda activate feat-env
 if [ "$TRAVIS_BRANCH" = "master" ]
 then
     echo "installing mkdocs"
-    conda install -c conda-forge mkdocs==1.1 mkdocs-material pymdown-extensions pygments
+    conda env update feat-env -f ci/docs-environment.yml
     echo "mkdocs version"
     mkdocs --version
 fi

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -36,7 +36,8 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.5 json-c=0.12.1-0 cython=0.29.12 scikit-learn pandas wheel setuptools=41.0.1
+# cython=0.29.12
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.5 json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools=41.0.1
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
 conda activate test-environment

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -27,25 +27,26 @@ sudo -H pip3 install mkdocs==1.1 mkdocs-material pymdown-extensions pygments
 echo "mkdocs version"
 mkdocs --version
 
-echo "installing eigen..."
 #wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz"
-wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2"
-tar xvjf 3.3.4.tar.bz2
-mkdir eigen-3.3.4
-mv eigen-eigen*/* eigen-3.3.4
+# wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2"
+# tar xvjf 3.3.4.tar.bz2
+# mkdir eigen-3.3.4
+# mv eigen-eigen*/* eigen-3.3.4
 
-export EIGEN3_INCLUDE_DIR="$(pwd)/eigen-3.3.4/"
-echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
 #_______________________________________________
 
-echo "installing shogun via conda..."
+echo "installing shogun and eigen via conda..."
 wget http://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 
 
 # conda update --yes conda
-conda install --yes -c conda-forge shogun-cpp
+conda install --yes -c conda-forge shogun-cpp eigen
+
+# export EIGEN3_INCLUDE_DIR="$(pwd)/eigen-3.3.4/"
+# echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
+# conda install -c conda-forge eigen
 
 # the new version of json-c seems to be missing a fn shogun is linked to;
 # force install of older version
@@ -87,7 +88,7 @@ cd $old_path; pwd
 echo "installing feat..."
 mkdir build;
 cd build; pwd
-cmake -DTEST=ON -DEIGEN_DIR=ON -DSHOGUN_DIR=ON ..
+cmake -DTEST=ON -DEIGEN_DIR=OFF -DSHOGUN_DIR=ON ..
 cd ..
 make -C build VERBOSE=1
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -69,4 +69,4 @@ cd $old_path; pwd
 echo "configuring feat..."
 ./configure tests
 echo "install feat..."
-./install tests y
+./install -C build -j 4 y

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -36,7 +36,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.4 json-c=0.12.1-0 cython=0.29.12 scikit-learn pandas wheel setuptools=41.0.1
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.5 json-c=0.12.1-0 cython=0.29.12 scikit-learn pandas wheel setuptools=41.0.1
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
 conda activate test-environment

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -14,7 +14,7 @@ hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
 # cython=0.29.12
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.5 json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools=41.0.1
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools=41.0.1
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
 conda activate test-environment
@@ -82,6 +82,3 @@ echo "installing wrapper"
 cd ./python
 python setup.py install
 cd ..
-
-echo "copying wrapper test to the python folder"
-sudo cp tests/wrappertest.py python/ #Copy the file to python folder

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -1,7 +1,7 @@
-echo "cmake version:"
-cmake --version
-echo "sudo cmake version:"
-sudo cmake --version
+# echo "cmake version:"
+# cmake --version
+# echo "sudo cmake version:"
+# sudo cmake --version
 
 ##########CONDA##############
 
@@ -18,7 +18,7 @@ conda config --set always_yes yes --set changeps1 no
 conda env create -f ci/test-environment.yml
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
-conda activate test
+conda activate feat-env
 
 # install packages for the docs
 if [ "$TRAVIS_BRANCH" = "master" ]
@@ -44,12 +44,12 @@ which cython
 ##########CONDA##############
 
 # set environment variables for eigen and shogun includes
-export EIGEN3_INCLUDE_DIR="$HOME/miniconda/envs/test/include/eigen3/"
+export EIGEN3_INCLUDE_DIR="$HOME/miniconda/envs/feat-env/include/eigen3/"
 echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
 
-export SHOGUN_LIB=/home/travis/miniconda/envs/test/lib/
+export SHOGUN_LIB=/home/travis/miniconda/envs/feat-env/lib/
 echo "SHOGUN_LIB set to $SHOGUN_LIB"
-export SHOGUN_DIR=/home/travis/miniconda/envs/test/include/
+export SHOGUN_DIR=/home/travis/miniconda/envs/feat-env/include/
 echo "SHOGUN_DIR set to $SHOGUN_DIR"
 
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -14,10 +14,11 @@ hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
 # cython=0.29.12
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools=41.0.1
+# conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools=41.0.1
+conda env create -f ci/test-environment.yml
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
-conda activate test-environment
+conda activate test
 
 # install packages for the docs
 if [ "$TRAVIS_BRANCH" = "master" ]
@@ -43,12 +44,12 @@ which cython
 ##########CONDA##############
 
 # set environment variables for eigen and shogun includes
-export EIGEN3_INCLUDE_DIR="$HOME/miniconda/envs/test-environment/include/eigen3/"
+export EIGEN3_INCLUDE_DIR="$HOME/miniconda/envs/test/include/eigen3/"
 echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
 
-export SHOGUN_LIB=/home/travis/miniconda/envs/test-environment/lib/
+export SHOGUN_LIB=/home/travis/miniconda/envs/test/lib/
 echo "SHOGUN_LIB set to $SHOGUN_LIB"
-export SHOGUN_DIR=/home/travis/miniconda/envs/test-environment/include/
+export SHOGUN_DIR=/home/travis/miniconda/envs/test/include/
 echo "SHOGUN_DIR set to $SHOGUN_DIR"
 
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -1,30 +1,7 @@
-echo "python path is..."
-which python
-python --version
-
-echo "cython path is..."
-which cython
-echo "installing cmake"
-# sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
-# sudo apt-get update -y
-# sudo apt-get install cmake
 echo "cmake version:"
 cmake --version
 echo "sudo cmake version:"
 sudo cmake --version
-
-# echo "installing pip"
-# sudo apt install python3-pip
-# echo "installing setuptools"
-# sudo -H pip3 install setuptools
-# echo "installing wheel"
-# sudo -H pip3 install wheel
-
-#wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz"
-# wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2"
-# tar xvjf 3.3.4.tar.bz2
-# mkdir eigen-3.3.4
-# mv eigen-eigen*/* eigen-3.3.4
 
 ##########CONDA##############
 
@@ -54,27 +31,6 @@ fi
 which conda
 conda info -a
 
-# conda update --yes conda
-# conda install --yes -c conda-forge shogun-cpp eigen
-
-# export EIGEN3_INCLUDE_DIR="$(pwd)/eigen-3.3.4/"
-# conda install -c conda-forge eigen
-
-# the new version of json-c seems to be missing a fn shogun is linked to;
-# force install of older version
-# conda install --yes json-c=0.12.1-0
-
-# commending out the following installs which should be triggered
-# by call to setup.py
-# echo "installing cython using conda..."
-# conda install --yes cython
-
-# echo "installing scikit-learn via conda..."
-# conda install --yes scikit-learn
-
-# echo "installing pandas via conda..."
-# conda install --yes pandas
-
 echo "printing conda environment"
 conda-env export
 
@@ -91,12 +47,13 @@ export EIGEN3_INCLUDE_DIR="$HOME/miniconda/envs/test-environment/include/eigen3/
 echo "EIGEN3_INCLUDE_DIR set to $EIGEN3_INCLUDE_DIR"
 
 export SHOGUN_LIB=/home/travis/miniconda/envs/test-environment/lib/
+echo "SHOGUN_LIB set to $SHOGUN_LIB"
 export SHOGUN_DIR=/home/travis/miniconda/envs/test-environment/include/
+echo "SHOGUN_DIR set to $SHOGUN_DIR"
 
 
 #building and installing google tests
 echo "installing google test"
-# sudo apt-get install libgtest-dev
 old_path=$(pwd)
 
 echo "building google test.."

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -59,8 +59,8 @@ old_path=$(pwd)
 
 echo "building google test.."
 cd /usr/src/gtest; echo "changed to $(pwd)"
-echo "ls"
-ls
+echo "which cmake?"
+which cmake
 sudo cmake CMakeLists.txt
 
 sudo make
@@ -75,6 +75,8 @@ cd $old_path; pwd
 echo "installing feat..."
 mkdir build;
 cd build; pwd
+echo "which cmake?"
+which cmake
 cmake -DTEST=ON -DEIGEN_DIR=ON -DSHOGUN_DIR=ON ..
 cd ..
 make -C build VERBOSE=1

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -36,7 +36,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.4 json-c=0.12.1-0 cython=0.29.12 scikit-learn pandas wheel setuptools
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.4 json-c=0.12.1-0 cython=0.29.12 scikit-learn pandas wheel setuptools=41.0.1
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
 conda activate test-environment

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -39,7 +39,7 @@ echo "installing shogun and eigen via conda..."
 wget http://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
-source "$HOME/miniconda/etc/profile.d/conda.sh"
+. "$HOME/miniconda/etc/profile.d/conda.sh"
 hash -r
 conda info -a
 echo "creating conda environment"

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -127,6 +127,3 @@ cd ..
 
 echo "copying wrapper test to the python folder"
 sudo cp tests/wrappertest.py python/ #Copy the file to python folder
-
-echo "running feat.."
-./build/feat docs/examples/data/d_enc.csv -rs 42 -g 2 -p 5

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -17,18 +17,8 @@ sudo cmake --version
 # sudo apt install python3-pip
 # echo "installing setuptools"
 # sudo -H pip3 install setuptools
-echo "installing wheel"
-sudo -H pip3 install wheel
-
-# install packages for the docs
-if [ "$TRAVIS_BRANCH" = "master" ]
-then
-    echo "installing mkdocs"
-    sudo -H pip3 install mkdocs==1.1 mkdocs-material pymdown-extensions pygments
-
-    echo "mkdocs version"
-    mkdocs --version
-fi
+# echo "installing wheel"
+# sudo -H pip3 install wheel
 
 #wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz"
 # wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2"
@@ -46,10 +36,19 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas setuptools
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
 conda activate test-environment
+
+# install packages for the docs
+if [ "$TRAVIS_BRANCH" = "master" ]
+then
+    echo "installing mkdocs"
+    conda install mkdocs==1.1 mkdocs-material pymdown-extensions pygments
+    echo "mkdocs version"
+    mkdocs --version
+fi
 
 conda info -a
 

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -39,8 +39,10 @@ echo "installing shogun and eigen via conda..."
 wget http://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
+source "$HOME/miniconda/etc/profile.d/conda.sh"
+hash -r
 echo "creating conda environment"
-conda config --set always_yes yes
+conda config --set always_yes yes --set changeps1 no
 conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 conda activate test-environment

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -4,7 +4,6 @@ python --version
 
 echo "cython path is..."
 which cython
-
 echo "installing cmake"
 # sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
 # sudo apt-get update -y
@@ -16,16 +15,20 @@ sudo cmake --version
 
 # echo "installing pip"
 # sudo apt install python3-pip
-echo "installing setuptools"
-sudo -H pip3 install setuptools
+# echo "installing setuptools"
+# sudo -H pip3 install setuptools
 echo "installing wheel"
 sudo -H pip3 install wheel
 
-echo "installing mkdocs"
-sudo -H pip3 install mkdocs==1.1 mkdocs-material pymdown-extensions pygments
+# install packages for the docs
+if [ "$TRAVIS_BRANCH" = "master" ]
+then
+    echo "installing mkdocs"
+    sudo -H pip3 install mkdocs==1.1 mkdocs-material pymdown-extensions pygments
 
-echo "mkdocs version"
-mkdocs --version
+    echo "mkdocs version"
+    mkdocs --version
+fi
 
 #wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz"
 # wget "http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2"
@@ -41,12 +44,14 @@ bash miniconda.sh -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 . "$HOME/miniconda/etc/profile.d/conda.sh"
 hash -r
-conda info -a
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas setuptools
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
+echo "activating test-environment"
 conda activate test-environment
+
+conda info -a
 
 # conda update --yes conda
 # conda install --yes -c conda-forge shogun-cpp eigen
@@ -71,6 +76,13 @@ conda activate test-environment
 
 echo "printing conda environment"
 conda-env export
+
+echo "python path is..."
+which python
+python --version
+
+echo "cython path is..."
+which cython
 ##########CONDA##############
 
 # set environment variables for eigen and shogun includes

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -19,7 +19,7 @@ sudo cmake --version
 echo "installing setuptools"
 sudo -H pip3 install setuptools
 echo "installing wheel"
-sudo -H pip3 install setuptools
+sudo -H pip3 install wheel
 
 echo "installing mkdocs"
 sudo -H pip3 install mkdocs==1.1 mkdocs-material pymdown-extensions pygments
@@ -33,7 +33,7 @@ mkdocs --version
 # mkdir eigen-3.3.4
 # mv eigen-eigen*/* eigen-3.3.4
 
-#_______________________________________________
+##########CONDA##############
 
 echo "installing shogun and eigen via conda..."
 wget http://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh -O miniconda.sh
@@ -64,6 +64,10 @@ conda install --yes scikit-learn
 
 echo "installing pandas via conda..."
 conda install --yes pandas
+
+echo "printing conda environment"
+conda-env export
+##########CONDA##############
 
 #building and installing google tests
 echo "installing google test"

--- a/ci/.travis_install.sh
+++ b/ci/.travis_install.sh
@@ -36,7 +36,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 echo "creating conda environment"
 conda config --set always_yes yes --set changeps1 no
-conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.7 json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools
+conda create -c conda-forge -q -n test-environment python=3.7 shogun-cpp=6.1.3 eigen=3.3.4 json-c=0.12.1-0 cython scikit-learn pandas wheel setuptools
 # conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION -c conda-forge shogun-cpp eigen json-c=0.12.1-0 cython scikit-learn pandas
 echo "activating test-environment"
 conda activate test-environment

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -12,7 +12,7 @@ echo "sourcing conda"
 which conda
 
 echo "reactivating test"
-conda activate test
+conda activate feat-env
 conda info -a
 echo "running wrapper test"
 python tests/wrappertest.py -v 1

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -4,6 +4,9 @@ echo "==========\nc++ tests\n=========="
 
 echo "==========\npython tests\n=========="
 # python tests
+echo "reactivating test-environment"
+conda activate test-environment
+conda info -a
 /home/travis/miniconda/bin/python3 python/wrappertest.py -v 1
 
 

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -5,7 +5,7 @@ echo "==========\nc++ tests\n=========="
 echo "==========\npython tests\n=========="
 # python tests
 echo "sourcing conda"
-. "$HOME/miniconda/etc/profile.d/conda.sh"
+source "$HOME/miniconda/etc/profile.d/conda.sh"
 hash -r
 echo "reactivating test-environment"
 /home/travis/miniconda/condabin/conda activate test-environment

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -11,8 +11,8 @@ echo "sourcing conda"
 . /home/travis/miniconda/etc/profile.d/conda.sh
 which conda
 
-echo "reactivating test-environment"
-conda activate test-environment
+echo "reactivating test"
+conda activate test
 conda info -a
 echo "running wrapper test"
 python tests/wrappertest.py -v 1

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -4,6 +4,9 @@ echo "==========\nc++ tests\n=========="
 
 echo "==========\npython tests\n=========="
 # python tests
+echo "sourcing conda"
+. "$HOME/miniconda/etc/profile.d/conda.sh"
+hash -r
 echo "reactivating test-environment"
 /home/travis/miniconda/condabin/conda activate test-environment
 /home/travis/miniconda/condabin/conda info -a

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -1,3 +1,6 @@
+echo "=========\njust a quick run====="
+./build/feat docs/examples/data/d_enc.csv -rs 42 -g 2 -p 5
+
 # feat c++ tests
 echo "==========\nc++ tests\n=========="
 ./build/tests
@@ -12,6 +15,6 @@ echo "reactivating test-environment"
 conda activate test-environment
 conda info -a
 echo "running wrapper test"
-/home/travis/miniconda/bin/python3 python/wrappertest.py -v 1
+python python/wrappertest.py -v 1
 
 

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -15,6 +15,6 @@ echo "reactivating test-environment"
 conda activate test-environment
 conda info -a
 echo "running wrapper test"
-python python/wrappertest.py -v 1
+python tests/wrappertest.py -v 1
 
 

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -5,8 +5,9 @@ echo "==========\nc++ tests\n=========="
 echo "==========\npython tests\n=========="
 # python tests
 echo "reactivating test-environment"
-conda activate test-environment
-conda info -a
+/home/travis/miniconda/condabin/conda activate test-environment
+/home/travis/miniconda/condabin/conda info -a
+echo "running wrapper test"
 /home/travis/miniconda/bin/python3 python/wrappertest.py -v 1
 
 

--- a/ci/.travis_test.sh
+++ b/ci/.travis_test.sh
@@ -5,11 +5,12 @@ echo "==========\nc++ tests\n=========="
 echo "==========\npython tests\n=========="
 # python tests
 echo "sourcing conda"
-source "$HOME/miniconda/etc/profile.d/conda.sh"
-hash -r
+. /home/travis/miniconda/etc/profile.d/conda.sh
+which conda
+
 echo "reactivating test-environment"
-/home/travis/miniconda/condabin/conda activate test-environment
-/home/travis/miniconda/condabin/conda info -a
+conda activate test-environment
+conda info -a
 echo "running wrapper test"
 /home/travis/miniconda/bin/python3 python/wrappertest.py -v 1
 

--- a/ci/docs-environment.yml
+++ b/ci/docs-environment.yml
@@ -5,5 +5,6 @@ channels:
 dependencies:
     - mkdocs=1.1
     - mkdocs-material
+    - mkdocs-material-extensions=1.*
     - pymdown-extensions
     - pygments

--- a/ci/docs-environment.yml
+++ b/ci/docs-environment.yml
@@ -1,0 +1,9 @@
+# note: this should be used to update feat-env only
+name: feat-env
+channels:
+    - conda-forge
+dependencies:
+    - mkdocs=1.1
+    - mkdocs-material
+    - pymdown-extensions
+    - pygments

--- a/ci/test-environment.yml
+++ b/ci/test-environment.yml
@@ -3,14 +3,14 @@ channels:
     - conda-forge
 dependencies:
     - python=3.*
-    - cmake=3.*
+    - cmake=3.18.*
     - eigen=3.3.*
-    - cython
-    - pandas
-    - scikit-learn
+    - cython=0.29.*
+    - pandas=1.1.*
+    - scikit-learn=0.23.*
     - setuptools=45.*
-    - shogun-cpp=6.1.3
-    - wheel
-    - pip
+    - shogun-cpp=6.1.4
+    - wheel=0.35.*
+    - pip=20.*
     - pip:
-        - eigency
+        - eigency=1.77

--- a/ci/test-environment.yml
+++ b/ci/test-environment.yml
@@ -1,0 +1,12 @@
+name: test
+channels:
+    - conda-forge
+dependencies:
+    - python=3.*
+    - eigen=3.3.*
+    - cython
+    - pandas
+    - scikit-learn
+    - setuptools=41.0.1
+    - shogun-cpp=6.1.3
+    - wheel

--- a/ci/test-environment.yml
+++ b/ci/test-environment.yml
@@ -10,3 +10,6 @@ dependencies:
     - setuptools=45.*
     - shogun-cpp=6.1.3
     - wheel
+    - pip
+    - pip:
+        - eigency

--- a/ci/test-environment.yml
+++ b/ci/test-environment.yml
@@ -1,8 +1,9 @@
-name: test
+name: feat-env
 channels:
     - conda-forge
 dependencies:
     - python=3.*
+    - cmake=3.*
     - eigen=3.3.*
     - cython
     - pandas

--- a/ci/test-environment.yml
+++ b/ci/test-environment.yml
@@ -7,6 +7,6 @@ dependencies:
     - cython
     - pandas
     - scikit-learn
-    - setuptools=41.0.1
+    - setuptools
     - shogun-cpp=6.1.3
     - wheel

--- a/ci/test-environment.yml
+++ b/ci/test-environment.yml
@@ -13,4 +13,4 @@ dependencies:
     - wheel=0.35.*
     - pip=20.*
     - pip:
-        - eigency=1.77
+        - eigency==1.77

--- a/ci/test-environment.yml
+++ b/ci/test-environment.yml
@@ -7,6 +7,6 @@ dependencies:
     - cython
     - pandas
     - scikit-learn
-    - setuptools
+    - setuptools=45.*
     - shogun-cpp=6.1.3
     - wheel

--- a/configure
+++ b/configure
@@ -43,6 +43,6 @@ elif [ "$1" == "gpu" ] ; then
     cd ..
 else
     rm -rf build; mkdir build; cd build; 
-    cmake -DSHOGUN_DIR=ON ..
+    cmake -DSHOGUN_DIR=ON -DEIGEN_DIR=ON ..
     cd ..
 fi

--- a/configure
+++ b/configure
@@ -2,6 +2,7 @@
 # ===
 # Configuration Options:
 # ./configure : builds a release version of feat.
+# ./configure tests: builds a release version of feat and the tests.
 # ./configure debug : builds a debug version of feat.
 # ./configure profile: build a version of feat use with profiling tools. 
 # ===
@@ -35,7 +36,7 @@ elif [ "$1" == "lpc_cuda" ] ; then
     cd ..
 elif [ "$1" == "tests" ] ; then 
     rm -rf build; mkdir build; cd build; 
-    cmake -DSHOGUN_DIR=ON .. -DTEST=ON ..
+    cmake -DSHOGUN_DIR=ON -DEIGEN_DIR=ON -DTEST=ON ..
     cd ..
 elif [ "$1" == "gpu" ] ; then
     rm -rf buildGPU; mkdir buildGPU; cd buildGPU; 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,25 +2,32 @@
 
 To see our installation process from scratch, check out the [Travis install file](http://github.com/lacava/feat/blob/master/ci/.travis_install.sh).
 
-Feat depends on the [Eigen](http://eigen.tuxfamily.org) matrix library for C++ as well as the [Shogun](http://shogun.ml) ML library. Both come in easy packages that work across platforms. If you need Eigen and Shogun, follow the instructions in [Dependencies](#dependencies). 
+#### Conda
 
-Feat uses [cmake](https://cmake.org/) to build. It uses the typical set of instructions:
-    
+The easiest option for install is to use the [conda environment we provide](http://github.com/lacava/feat/blob/master/ci/test-environment.yml). 
+Then the build process is the following:
+
     git clone https://github.com/lacava/feat # clone the repo
     cd feat # enter the directory
+    conda create env -f ci/test-environment.yml
+    conda activate feat-env
+    #add some environment variables
+    export SHOGUN_LIB=/path/to/anaconda/envs/feat-env/lib/
+    export SHOGUN_DIR=/path/to/anaconda/envs/feat-env/include/
+    export EIGEN3_INCLUDE_DIR=/path/to/anaconda/envs/feat-env/include/eigen3/
+    # install feat
     ./configure # this runs "mkdir build; cd build; cmake .. " 
-    ./install # this runs "make -C build VERBOSE=1 -j8"
+    ./install # this runs "make -C build VERBOSE=1 -j8; python setup.py install"
+    
 
-## Python wrapper
-
-The python wrapper is installed using setuptools as follows: 
-
-```bash
-cd python
-python setup.py install
-```
+If you want to roll your own with the dependencies, some other options are shown below. 
 
 ## Dependencies
+
+Feat uses [cmake](https://cmake.org/) to build. 
+It also depends on the [Eigen](http://eigen.tuxfamily.org) matrix library for C++ as well as the [Shogun](http://shogun.ml) ML library. 
+Both come in packages on conda that should work across platforms. 
+If you need Eigen and Shogun and don't want to use conda, follow these instructions. 
 
 ### Eigen 
 
@@ -48,17 +55,6 @@ export EIGEN3_INCLUDE_DIR="$(pwd)/eigen-3.3.4/"
 
 You don't have to compile Shogun, just download the binaries. [Their install guide is good.](https://github.com/shogun-toolbox/shogun/blob/develop/doc/readme/INSTALL.md#binaries) We've listed two of the options here.
 
-#### Anaconda
-
-A good option for Anaconda users is the Shogun Anaconda package. If you use conda, you can get what you need by 
-
-    conda install -c conda-forge shogun-cpp
-
-If you do this, you need tell cmake where to find Anaconda's library and include directories. 
-Set these two variables appropriately:
-
-    export SHOGUN_LIB=/home/travis/miniconda/lib/
-    export SHOGUN_DIR=/home/travis/miniconda/include/
 
 #### Debian/Ubuntu
 

--- a/install
+++ b/install
@@ -2,37 +2,53 @@
 
 check_for_python=true
 choice="n"
-nobuild=false
+njobs=""
+folder="build"
 
-if [ $# > 0 ] ; then 
-    for var in $@ ; do
-        if [ $var == "debug" ] ; then
-            make -C debug -j
-        elif [ $var == "profile" ] ; then
-            make -C profile -j
-        elif [ $var == "lpc" ] ; then
-            module load gcc/5.2.0
-            export EIGEN3_INCLUDE_DIR="$HOME/eigen-3.3.4/"
-            export SHOGUN_DIR="$HOME/anaconda3/include/"
-            export SHOGUN_LIB="$HOME/anaconda3/lib/"    
-        elif [ $var == "n" ] ; then
-            check_for_python=false
-        elif [ $var == "y" ] || [ $var == "python" ] ; then
-            # echo "installing python module..."
-            # cd python
-            # rm -rf build 
-            # rm -rf dist
-            # python setup.py install
-            # cd ..
-            check_for_python=false
-            choice="y"
-        fi 
-    done
-fi
+POSITIONAL=()
+while [[ $# > 0 ]]
+do
+    key="$1"
 
-if [ $nobuild == false ] ; then
-    make -C build -j 
-fi
+    case $key in 
+    -C)
+        folder=$2
+        shift
+        shift
+        ;;
+    lpc)
+        module load gcc/5.2.0
+        export EIGEN3_INCLUDE_DIR="$HOME/eigen-3.3.4/"
+        export SHOGUN_DIR="$HOME/anaconda3/include/"
+        export SHOGUN_LIB="$HOME/anaconda3/lib/"    
+        shift
+        ;;
+    n)
+        check_for_python=false
+        shift
+        ;;
+    y)
+        check_for_python=false
+        choice="y"
+        shift
+        ;;
+    -j|njobs)
+        njobs="$2"
+        shift
+        shift
+        ;;
+    *) # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+   esac
+done
+
+echo "Build folder = ${folder}"
+echo "Numer of jobs = ${njobs}"
+
+make -C ${folder} -j ${njobs}
+
 if [ $check_for_python == true ] ; then
     read -p "Install python wrapper? (y/n) " choice
 fi

--- a/python/setup.py
+++ b/python/setup.py
@@ -78,7 +78,7 @@ setup(
         include_dirs = ['../build/','../src/',eigen_dir,shogun_include_dir]
                           +eigency.get_includes(include_eigen=False),
         extra_compile_args = ['-std=c++1y','-fopenmp','-Wno-sign-compare',
-                                 '-Wno-reorder'],
+                                 '-Wno-reorder','-Wno-unused-variable'],
         library_dirs = [shogun_lib,feat_lib],
         runtime_library_dirs = [feat_lib],
         extra_link_args = ['-lshogun','-lfeat_lib'],      

--- a/python/versionstr.py
+++ b/python/versionstr.py
@@ -1,1 +1,1 @@
-__version__="0.4.post13"
+__version__="0.4.post37"


### PR DESCRIPTION
This PR overhauls the CI installation process and updates the documentation to suggest using conda for managing all the dependencies. As discussed in issues #263 and #264, specifying a conda environment seems to be the best bet for managing Feat's dependencies (shogun, eigen, cmake, setuptools, etc). This PR includes an environment file (ci/test-environment.yml) that can be used to set up an environment for installing Feat. That environment is also used by the tests. 

This also fixes #265 by installing eigen from conda instead of from the eigen repository. 